### PR TITLE
feat(data)[#5]: preprocess pipeline (validate, embed, ID mapping, mini builder)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev lint format test test-cov typecheck precommit download clean
+.PHONY: help install install-dev lint format test test-cov typecheck precommit download preprocess clean
 
 SRC = src/riemannfm
 TESTS = tests
@@ -49,8 +49,11 @@ test-cov: ## Run tests with coverage
 	$(RUN) pytest $(TESTS) -v --cov=$(SRC) --cov-report=term-missing --cov-report=html
 
 # ─── Data ─────────────────────────────────────────────────────────────
-download: ## Download datasets and precompute text embeddings
+download: ## Download datasets
 	$(RUN) python -m riemannfm.cli.download $(ARGS)
+
+preprocess: ## Build id mappings and precompute text embeddings
+	$(RUN) python -m riemannfm.cli.preprocess $(ARGS)
 
 # ─── Cleanup ──────────────────────────────────────────────────────────
 clean: ## Remove build artifacts

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -2,6 +2,8 @@ defaults:
   - paths: default
   - data: wikidata_5m
   - download: default
+  - preprocess: default
+  - embedding: qwen3
   - _self_
 
 seed: 42

--- a/configs/data/wikidata_5m_mini.yaml
+++ b/configs/data/wikidata_5m_mini.yaml
@@ -1,0 +1,12 @@
+# Engineering-validation subset of wikidata_5m produced by
+# 'riemannfm-preprocess data=wikidata_5m preprocess.build_mini=true'.
+# It is NOT independently downloadable; use this config after running
+# the mini builder. Fields match the other data configs' download-scope
+# slice: slug / dataset / data_dir / text_source + dataset-identity
+# counts. Datamodule hyperparameters arrive in a later Issue.
+slug: wikidata_5m_mini
+dataset: wikidata
+data_dir: ${paths.data_dir}/wikidata_5m_mini
+num_entities: 7833
+num_edge_types: 822
+text_source: wikidata_description

--- a/configs/embedding/qwen3.yaml
+++ b/configs/embedding/qwen3.yaml
@@ -1,0 +1,7 @@
+embedding_provider: ollama
+model_name: ${oc.env:OLLAMA_EMBEDDING_MODEL_NAME,qwen3-embedding:8b}
+api_base: ${oc.env:OLLAMA_BASE_URL,http://localhost:11434}
+output_dim: 768
+freeze: true
+pooling: last_token
+max_length: 512

--- a/configs/preprocess/default.yaml
+++ b/configs/preprocess/default.yaml
@@ -2,7 +2,10 @@ batch_size: 256
 device: cuda
 force: false
 
-# Mini dataset builder (relation-aware sampling)
+# Mini dataset builder (relation-aware sampling).
+# mini_min_* are floors (Phase 1 per-relation sampling and Phase 2 entity
+# top-up). Phase 3 densify has no upper bound, so actual output is
+# typically several x larger. See build_mini_wikidata_5m docstring.
 build_mini: false
-mini_max_entities: 1000
-mini_target_triples: 5000
+mini_min_entities: 1000
+mini_min_triples: 5000

--- a/configs/preprocess/default.yaml
+++ b/configs/preprocess/default.yaml
@@ -1,0 +1,8 @@
+batch_size: 256
+device: cuda
+force: false
+
+# Mini dataset builder (relation-aware sampling)
+build_mini: false
+mini_max_entities: 1000
+mini_target_triples: 5000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
 
 [project.scripts]
 riemannfm-download = "riemannfm.cli.download:main"
+riemannfm-preprocess = "riemannfm.cli.preprocess:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/preprocess.sh
+++ b/scripts/preprocess.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
+activate_env
+ensure_dirs
+log_header "Preprocess" "$*"
+
+run_module riemannfm.cli.preprocess "$@"

--- a/src/riemannfm/cli/preprocess.py
+++ b/src/riemannfm/cli/preprocess.py
@@ -29,8 +29,8 @@ def main(cfg: DictConfig):
         build_mini_wikidata_5m(
             source_dir=cfg.data.data_dir,
             output_dir=str(Path(cfg.data.data_dir).parent / "wikidata_5m_mini"),
-            max_entities=cfg.preprocess.get("mini_max_entities", 1000),
-            target_triples=cfg.preprocess.get("mini_target_triples", 5000),
+            min_entities=cfg.preprocess.get("mini_min_entities", 1000),
+            min_triples=cfg.preprocess.get("mini_min_triples", 5000),
             force=cfg.preprocess.force,
         )
         return

--- a/src/riemannfm/cli/preprocess.py
+++ b/src/riemannfm/cli/preprocess.py
@@ -1,0 +1,52 @@
+"""CLI for preprocessing KG datasets.
+
+Builds ID mappings (string → int) and precomputes text embeddings.
+Reads from data/{dataset}/raw/, writes to data/{dataset}/processed/.
+
+Usage:
+    python -m riemannfm.cli.preprocess data=wikidata_5m embedding=sbert
+    python -m riemannfm.cli.preprocess data=fb15k237 embedding=qwen3
+
+Build mini validation dataset from full WikiData5M:
+    python -m riemannfm.cli.preprocess data=wikidata_5m preprocess.build_mini=true
+"""
+
+import logging
+
+import hydra
+from omegaconf import DictConfig
+
+from riemannfm.data.pipeline.preprocess import build_mini_wikidata_5m, run_preprocess
+
+logger = logging.getLogger(__name__)
+
+
+@hydra.main(version_base=None, config_path="../../../configs", config_name="config")
+def main(cfg: DictConfig):
+    if cfg.preprocess.build_mini:
+        logger.info("Building mini WikiData5M validation dataset...")
+        build_mini_wikidata_5m(
+            source_dir=cfg.data.data_dir,
+            max_entities=cfg.preprocess.get("mini_max_entities", 1000),
+            target_triples=cfg.preprocess.get("mini_target_triples", 5000),
+            force=cfg.preprocess.force,
+        )
+        return
+
+    run_preprocess(
+        data_dir=cfg.data.data_dir,
+        embedding_provider=cfg.embedding.embedding_provider,
+        model_name=cfg.embedding.model_name,
+        output_dim=cfg.embedding.output_dim,
+        batch_size=cfg.preprocess.batch_size,
+        max_length=cfg.embedding.get("max_length", 512),
+        pooling=cfg.embedding.get("pooling", "mean"),
+        api_base=cfg.embedding.get("api_base", None),
+        api_key=cfg.embedding.get("api_key", None),
+        force=cfg.preprocess.force,
+    )
+    logger.info("Preprocess complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/riemannfm/cli/preprocess.py
+++ b/src/riemannfm/cli/preprocess.py
@@ -12,6 +12,7 @@ Build mini validation dataset from full WikiData5M:
 """
 
 import logging
+from pathlib import Path
 
 import hydra
 from omegaconf import DictConfig
@@ -27,6 +28,7 @@ def main(cfg: DictConfig):
         logger.info("Building mini WikiData5M validation dataset...")
         build_mini_wikidata_5m(
             source_dir=cfg.data.data_dir,
+            output_dir=str(Path(cfg.data.data_dir).parent / "wikidata_5m_mini"),
             max_entities=cfg.preprocess.get("mini_max_entities", 1000),
             target_triples=cfg.preprocess.get("mini_target_triples", 5000),
             force=cfg.preprocess.force,

--- a/src/riemannfm/data/pipeline/embed.py
+++ b/src/riemannfm/data/pipeline/embed.py
@@ -1,0 +1,458 @@
+"""Multi-backend text embedding for KG entities and relations.
+
+Supports three embedding providers:
+- huggingface: Local transformer models (SBERT)
+- ollama: Ollama server via OpenAI-compatible /v1/embeddings endpoint (Qwen3, Nomic)
+- openai: OpenAI API via /v1/embeddings endpoint
+
+Results are cached to disk. Embedding files are named
+entity_emb_{encoder}_{dim}.pt for ablation coexistence.
+"""
+
+import logging
+import os
+import random
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor
+from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
+
+# ─── Encoder slug mapping ────────────────────────────────────────────────────
+
+_SLUG_MAP: dict[str, str] = {
+    "sentence-transformers/all-MiniLM-L6-v2": "sbert",
+    "all-minilm:l6-v2": "sbert",
+    "qwen3-embedding": "qwen3",
+    "qwen3-embedding:8b": "qwen3",
+    "nomic-embed-text": "nomic",
+}
+
+_SLUG_TO_MODEL: dict[str, str] = {
+    "sbert": "sentence-transformers/all-MiniLM-L6-v2",
+    "qwen3": "qwen3-embedding:8b",
+    "nomic": "nomic-embed-text",
+}
+
+ENCODER_DIMS: dict[str, int] = {
+    "sbert": 384,
+    "qwen3": 768,
+    "nomic": 768,
+}
+
+
+def encoder_slug(text_encoder: str) -> str:
+    """Derive a filesystem-safe short key from a model name or config key.
+
+    Args:
+        text_encoder: Model name, HuggingFace path, or short slug.
+
+    Returns:
+        Short key like "sbert", "nomic", "qwen3".
+    """
+    if text_encoder in _SLUG_MAP:
+        return _SLUG_MAP[text_encoder]
+    if text_encoder in _SLUG_TO_MODEL:
+        return text_encoder
+    return text_encoder.split("/")[-1].replace("-", "_").lower()
+
+
+def encoder_model_name(text_encoder: str) -> str:
+    """Resolve a short slug to the full model name.
+
+    Args:
+        text_encoder: Short slug or full model name.
+
+    Returns:
+        Full model name.
+    """
+    if text_encoder in _SLUG_TO_MODEL:
+        return _SLUG_TO_MODEL[text_encoder]
+    return text_encoder
+
+
+def embedding_filename(encoder_key: str, dim: int, prefix: str = "entity") -> str:
+    """Build the deterministic embedding filename.
+
+    Args:
+        encoder_key: Short encoder slug.
+        dim: Embedding dimension.
+        prefix: File prefix ("entity" or "relation").
+
+    Returns:
+        Filename like "entity_emb_sbert_384.pt".
+    """
+    return f"{prefix}_emb_{encoder_key}_{dim}.pt"
+
+
+# ─── Multi-backend embedder ──────────────────────────────────────────────────
+
+
+class RiemannFMTextEmbedder:
+    """Encode texts into embeddings via HuggingFace, Ollama, or OpenAI.
+
+    Args:
+        embedding_provider: Backend to use ("huggingface", "ollama", "openai").
+        model_name: Model identifier (HF path or API model name).
+        output_dim: Expected output embedding dimension.
+        api_base: API base URL for ollama/openai backends.
+        api_key: API key for openai backend (default: reads OPENAI_API_KEY env).
+        batch_size: Batch size for encoding.
+        max_length: Maximum token length (huggingface only).
+        pooling: Pooling strategy for huggingface ("mean" or "last_token").
+        max_workers: Max concurrent requests for API backends (default: 8).
+    """
+
+    def __init__(
+        self,
+        embedding_provider: str = "huggingface",
+        model_name: str = "sentence-transformers/all-MiniLM-L6-v2",
+        output_dim: int = 384,
+        api_base: str | None = None,
+        api_key: str | None = None,
+        batch_size: int = 256,
+        max_length: int = 512,
+        pooling: str = "mean",
+        max_workers: int = 8,
+    ):
+        self.embedding_provider = embedding_provider
+        self.model_name = model_name
+        self.output_dim = output_dim
+        self.api_base = api_base
+        self.api_key = api_key
+        self.batch_size = batch_size
+        self.max_length = max_length
+        self.pooling = pooling
+        self.max_workers = max_workers
+
+        # Lazy-loaded HuggingFace model
+        self._hf_tokenizer: object | None = None
+        self._hf_model: torch.nn.Module | None = None
+
+    def embed(
+        self,
+        texts: list[str],
+        output_path: Path | None = None,
+        shard_size: int = 10000,
+    ) -> Tensor:
+        """Encode texts into embeddings with checkpoint support.
+
+        Large datasets are processed in shards and saved to a checkpoint
+        directory next to ``output_path``.  If the process is interrupted,
+        re-running will skip already-completed shards and resume from the
+        first missing one.
+
+        A persistent log file (``embed_{encoder}.log``) is written next to
+        ``output_path`` so that errors, retries, and progress can be reviewed
+        after the run completes.
+
+        Args:
+            texts: List of text strings to encode.
+            output_path: If provided, save/load embeddings at this path.
+            shard_size: Number of texts per checkpoint shard (default 10 000).
+
+        Returns:
+            Embeddings tensor, shape (len(texts), output_dim).
+        """
+        # ── Attach a persistent file logger for this run ──────────────────
+        file_handler: logging.FileHandler | None = None
+        if output_path is not None:
+            slug = encoder_slug(self.model_name)
+            log_path = output_path.parent / f"embed_{slug}.log"
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            file_handler = logging.FileHandler(log_path, mode="a", encoding="utf-8")
+            file_handler.setLevel(logging.DEBUG)
+            file_handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(name)s — %(message)s"))
+            logging.getLogger("riemannfm.data.pipeline.embed").addHandler(file_handler)
+            logger.info(f"Embedding log → {log_path}")
+
+        try:
+            return self._embed_with_checkpoints(texts, output_path, shard_size)
+        finally:
+            if file_handler is not None:
+                logging.getLogger("riemannfm.data.pipeline.embed").removeHandler(file_handler)
+                file_handler.close()
+
+    def _embed_with_checkpoints(
+        self,
+        texts: list[str],
+        output_path: Path | None,
+        shard_size: int,
+    ) -> Tensor:
+        """Inner implementation of embed() with checkpoint logic."""
+        if output_path is not None and output_path.exists():
+            cached: Tensor = torch.load(output_path, map_location="cpu", weights_only=True)
+            logger.info(f"Loaded cached embeddings ({cached.shape}) from {output_path}")
+            return cached
+
+        # For small datasets or no output_path, run without checkpointing
+        if output_path is None or len(texts) <= shard_size:
+            result = self._embed_batch(texts)
+            if output_path is not None:
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                torch.save(result, output_path)
+                logger.info(f"Saved embeddings ({result.shape}) to {output_path}")
+            return result
+
+        # ── Checkpointed path for large datasets ───────────────────────────
+        ckpt_dir = output_path.parent / f"_checkpoints_{output_path.stem}"
+        ckpt_dir.mkdir(parents=True, exist_ok=True)
+
+        n_shards = (len(texts) + shard_size - 1) // shard_size
+        logger.info(
+            f"Embedding {len(texts):,} texts in {n_shards} shards (shard_size={shard_size:,}), checkpoints → {ckpt_dir}"
+        )
+
+        # Count already-completed shards for progress bar initial position
+        done_shards = sum(1 for si in range(n_shards) if (ckpt_dir / f"shard_{si:05d}.pt").exists())
+        if done_shards > 0:
+            logger.info(f"Resuming: {done_shards}/{n_shards} shards already done")
+
+        shard_pbar = tqdm(
+            range(n_shards),
+            desc="Shards",
+            initial=done_shards,
+            total=n_shards,
+            unit="shard",
+        )
+        for shard_idx in shard_pbar:
+            shard_path = ckpt_dir / f"shard_{shard_idx:05d}.pt"
+            if shard_path.exists():
+                continue
+
+            start = shard_idx * shard_size
+            end = min(start + shard_size, len(texts))
+            shard_pbar.set_postfix_str(f"texts [{start:,}..{end:,})")
+            shard_emb = self._embed_batch(texts[start:end])
+            # Atomic write: tmp → rename, prevents corrupt checkpoint on crash
+            tmp_path = shard_path.with_suffix(".pt.tmp")
+            torch.save(shard_emb, tmp_path)
+            os.replace(tmp_path, shard_path)
+        shard_pbar.close()
+
+        # ── Concatenate all shards into final output ───────────────────────
+        logger.info("Concatenating shards...")
+        all_shards = []
+        for shard_idx in range(n_shards):
+            shard_path = ckpt_dir / f"shard_{shard_idx:05d}.pt"
+            all_shards.append(torch.load(shard_path, map_location="cpu", weights_only=True))
+
+        result = torch.cat(all_shards, dim=0)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(result, output_path)
+        logger.info(f"Saved embeddings ({result.shape}) to {output_path}")
+
+        # Clean up checkpoint directory
+        for f in ckpt_dir.iterdir():
+            f.unlink()
+        ckpt_dir.rmdir()
+        logger.info(f"Cleaned up checkpoint directory: {ckpt_dir}")
+
+        return result
+
+    def _embed_batch(self, texts: list[str]) -> Tensor:
+        """Dispatch to the correct backend for a batch of texts."""
+        if self.embedding_provider == "huggingface":
+            return self._embed_huggingface(texts)
+        if self.embedding_provider in ("ollama", "openai"):
+            return self._embed_openai_compat(texts)
+        if self.embedding_provider == "none":
+            return torch.zeros(len(texts), self.output_dim)
+        raise ValueError(f"Unknown embedding_provider: {self.embedding_provider}")
+
+    @torch.no_grad()
+    def _embed_huggingface(self, texts: list[str]) -> Tensor:
+        """Encode texts using a local HuggingFace transformer model."""
+        self._load_hf_model()
+        assert self._hf_model is not None
+        assert self._hf_tokenizer is not None
+
+        all_embeds = []
+        for i in tqdm(range(0, len(texts), self.batch_size), desc="Encoding (HF)"):
+            batch_texts = texts[i : i + self.batch_size]
+            inputs = self._hf_tokenizer(  # type: ignore[operator]
+                batch_texts,
+                max_length=self.max_length,
+                padding=True,
+                truncation=True,
+                return_tensors="pt",
+            )
+            if torch.cuda.is_available():
+                inputs = {k: v.cuda() for k, v in inputs.items()}
+
+            outputs = self._hf_model(**inputs)  # type: ignore[operator]
+
+            if self.pooling == "last_token":
+                # Use the last non-padding token
+                seq_len = inputs["attention_mask"].sum(dim=1) - 1
+                embeds = outputs.last_hidden_state[torch.arange(len(batch_texts)), seq_len]
+            else:
+                # Mean pooling (default)
+                mask = inputs["attention_mask"].unsqueeze(-1).float()
+                embeds = (outputs.last_hidden_state * mask).sum(dim=1) / mask.sum(dim=1).clamp(min=1)
+
+            all_embeds.append(embeds.cpu())
+
+        return torch.cat(all_embeds, dim=0)
+
+    def _embed_openai_compat(self, texts: list[str]) -> Tensor:
+        """Encode texts via OpenAI-compatible /v1/embeddings API.
+
+        Works with both OpenAI and Ollama (which exposes /v1/embeddings).
+        Sends concurrent requests (max_workers) with per-batch retry
+        and exponential backoff for robustness on long-running jobs.
+
+        Logs a summary at the end with success/retry/failure counts and
+        text index ranges of any failed batches.
+        """
+        import concurrent.futures
+
+        try:
+            from openai import OpenAI
+        except ImportError as e:
+            raise ImportError(
+                "openai package required for ollama/openai embedding_provider. Install with: pip install openai"
+            ) from e
+
+        api_base = self.api_base
+        if self.embedding_provider == "ollama" and api_base is None:
+            api_base = "http://localhost:11434"
+
+        # Ollama's OpenAI-compat endpoint is at /v1
+        if api_base and not api_base.endswith("/v1"):
+            api_base = f"{api_base}/v1"
+
+        client = OpenAI(
+            base_url=api_base,
+            api_key=self.api_key or "ollama",  # Ollama ignores api_key
+            max_retries=5,
+            timeout=120.0,
+        )
+
+        # Build batch index → texts mapping
+        batches: list[tuple[int, list[str]]] = []
+        for i in range(0, len(texts), self.batch_size):
+            batches.append((i, texts[i : i + self.batch_size]))
+
+        max_attempts = 5
+
+        # ── Tracking counters ─────────────────────────────────────────────
+        retried_batches: set[int] = set()  # batches that failed >= 1 attempt
+
+        def _encode_batch(batch_idx: int, batch_texts: list[str]) -> Tensor:
+            """Encode a single batch with exponential backoff retry."""
+            for attempt in range(max_attempts):
+                try:
+                    response = client.embeddings.create(
+                        model=self.model_name,
+                        input=batch_texts,
+                    )
+                    if attempt > 0:
+                        retried_batches.add(batch_idx)
+                        logger.info(f"Batch {batch_idx} succeeded on attempt {attempt + 1}")
+                    return torch.stack([torch.tensor(item.embedding) for item in response.data])
+                except Exception as e:
+                    if attempt == max_attempts - 1:
+                        raise
+                    delay = (2**attempt) + random.uniform(0, 1)
+                    logger.warning(
+                        f"Batch {batch_idx} (texts [{batch_idx * self.batch_size}..]) "
+                        f"failed (attempt {attempt + 1}/{max_attempts}): "
+                        f"{e!r} — retrying in {delay:.1f}s"
+                    )
+                    time.sleep(delay)
+            raise RuntimeError("unreachable")  # for type checker
+
+        # Concurrent requests for throughput
+        results: list[Tensor | None] = [None] * len(batches)
+        failed: list[tuple[int, list[str]]] = []
+        pbar = tqdm(total=len(batches), desc="Encoding (API)")
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_workers) as pool:
+            futures = {
+                pool.submit(_encode_batch, idx, batch_texts): idx for idx, (_, batch_texts) in enumerate(batches)
+            }
+            for future in concurrent.futures.as_completed(futures):
+                idx = futures[future]
+                try:
+                    results[idx] = future.result()
+                except Exception as e:
+                    logger.error(
+                        f"Batch {idx} (texts [{idx * self.batch_size}..]) failed after {max_attempts} attempts: {e!r}"
+                    )
+                    failed.append((idx, batches[idx][1]))
+                pbar.update(1)
+        pbar.close()
+
+        # Sequential retry for batches that failed all concurrent attempts
+        seq_recovered: list[int] = []
+        permanently_failed: list[int] = []
+        if failed:
+            logger.warning(f"Retrying {len(failed)} failed batch(es) sequentially...")
+            for idx, batch_texts in failed:
+                delay = 10.0
+                for retry in range(max_attempts):
+                    try:
+                        results[idx] = _encode_batch(idx, batch_texts)
+                        logger.info(f"Batch {idx} succeeded on sequential retry {retry + 1}")
+                        seq_recovered.append(idx)
+                        break
+                    except Exception as e:
+                        if retry == max_attempts - 1:
+                            permanently_failed.append(idx)
+                            raise RuntimeError(
+                                f"Batch {idx} (texts [{idx * self.batch_size}..]) "
+                                f"failed permanently after all retries: {e!r}"
+                            ) from e
+                        logger.warning(f"Sequential retry {retry + 1} for batch {idx}: {e!r}")
+                        time.sleep(delay)
+                        delay *= 2
+
+        # ── Summary ───────────────────────────────────────────────────────
+        n_total = len(batches)
+        n_failed_concurrent = len(failed)
+        n_recovered = len(seq_recovered)
+        n_permanent = len(permanently_failed)
+        n_retried_inline = len(retried_batches - {idx for idx, _ in failed})
+        n_first_try = n_total - n_retried_inline - n_failed_concurrent
+
+        summary_lines = [
+            f"Embedding summary: {n_total} batches, {len(texts):,} texts, batch_size={self.batch_size}",
+            f"  first-try success : {n_first_try}",
+            f"  retried (in-line) : {n_retried_inline}",
+            f"  failed→sequential : {n_failed_concurrent}",
+            f"    recovered       : {n_recovered}",
+            f"    permanent fail  : {n_permanent}",
+        ]
+        if permanently_failed:
+            ranges = [
+                f"[{idx * self.batch_size}..{min((idx + 1) * self.batch_size, len(texts))})"
+                for idx in permanently_failed
+            ]
+            summary_lines.append(f"  failed text ranges: {', '.join(ranges)}")
+
+        summary = "\n".join(summary_lines)
+        logger.info(summary)
+
+        out = torch.cat([r for r in results if r is not None], dim=0)
+        # Truncate to output_dim (supports Matryoshka embeddings like qwen3).
+        if out.shape[-1] > self.output_dim:
+            logger.info(f"Truncating embeddings from {out.shape[-1]} to {self.output_dim} (Matryoshka truncation)")
+            out = out[..., : self.output_dim]
+        return out
+
+    def _load_hf_model(self):
+        """Lazy-load HuggingFace model and tokenizer."""
+        if self._hf_model is not None:
+            return
+        from transformers import AutoModel, AutoTokenizer
+
+        logger.info(f"Loading HuggingFace model: {self.model_name}")
+        self._hf_tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+        self._hf_model = AutoModel.from_pretrained(self.model_name)
+        self._hf_model.eval()
+        if torch.cuda.is_available():
+            self._hf_model = self._hf_model.cuda()

--- a/src/riemannfm/data/pipeline/preprocess.py
+++ b/src/riemannfm/data/pipeline/preprocess.py
@@ -1,0 +1,497 @@
+"""Preprocessing: ID mapping and text embedding precomputation.
+
+Reads raw/ data (string-ID triples, entity/relation texts) and produces
+processed/ outputs (int tensors, embedding vectors).
+
+Two stages:
+1. Build entity2id / relation2id mappings, convert triples to int tensors
+2. Precompute text embeddings for entities and relations
+
+Additionally provides `build_mini_wikidata_5m` for creating a small
+engineering validation subset from the full WikiData5M download.
+"""
+
+import logging
+import random
+from collections import defaultdict
+from pathlib import Path
+
+import torch
+
+from riemannfm.data.pipeline.embed import (
+    RiemannFMTextEmbedder,
+    embedding_filename,
+    encoder_slug,
+)
+
+logger = logging.getLogger(__name__)
+
+# ─── Triple file name conventions ────────────────────────────────────────────
+
+_SPLIT_NAMES: dict[str, list[str]] = {
+    "train": ["train_triples.txt", "train.txt"],
+    "val": ["val_triples.txt", "valid.txt"],
+    "test": ["test_triples.txt", "test.txt"],
+}
+
+
+def _find_split_file(raw_dir: Path, split: str) -> Path | None:
+    """Find the triple file for a given split."""
+    for name in _SPLIT_NAMES.get(split, []):
+        path = raw_dir / name
+        if path.exists():
+            return path
+    return None
+
+
+# ─── Stage 1: ID mappings ────────────────────────────────────────────────────
+
+
+def build_id_mappings(
+    raw_dir: Path,
+    processed_dir: Path,
+    force: bool = False,
+) -> tuple[dict[str, int], dict[str, int]]:
+    """Build entity2id and relation2id from raw triples, save int tensors.
+
+    Reads all triple files (train/val/test), collects unique entity and
+    relation string IDs, assigns consecutive integer IDs, and saves:
+    - processed/entity2id.tsv
+    - processed/relation2id.tsv
+    - processed/{split}_triples.pt (int tensors)
+
+    Args:
+        raw_dir: Path to raw/ directory with triple files.
+        processed_dir: Path to processed/ directory for output.
+        force: Rebuild even if files exist.
+
+    Returns:
+        (entity2id, relation2id) dictionaries.
+    """
+    processed_dir.mkdir(parents=True, exist_ok=True)
+
+    entity2id_path = processed_dir / "entity2id.tsv"
+    relation2id_path = processed_dir / "relation2id.tsv"
+
+    # Check if already built
+    if entity2id_path.exists() and relation2id_path.exists() and not force:
+        entity2id = _load_id_mapping(entity2id_path)
+        relation2id = _load_id_mapping(relation2id_path)
+
+        # Verify triples exist too
+        all_exist = all((processed_dir / f"{split}_triples.pt").exists() for split in _SPLIT_NAMES)
+        if all_exist:
+            logger.info(
+                f"ID mappings already exist ({len(entity2id)} entities, {len(relation2id)} relations), skipping."
+            )
+            return entity2id, relation2id
+
+    # Collect all entities and relations from all splits
+    logger.info("Building ID mappings from raw triples...")
+    entities: set[str] = set()
+    relations: set[str] = set()
+    split_triples: dict[str, list[tuple[str, str, str]]] = {}
+
+    for split in _SPLIT_NAMES:
+        path = _find_split_file(raw_dir, split)
+        if path is None:
+            logger.warning(f"Split file not found for '{split}' in {raw_dir}")
+            split_triples[split] = []
+            continue
+
+        triples: list[tuple[str, str, str]] = []
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                parts = line.strip().split("\t")
+                if len(parts) == 3:
+                    h, r, t = parts
+                    entities.add(h)
+                    entities.add(t)
+                    relations.add(r)
+                    triples.append((h, r, t))
+
+        split_triples[split] = triples
+        logger.info(f"  {split}: {len(triples)} triples")
+
+    # Assign IDs (sorted for determinism)
+    entity2id = {e: i for i, e in enumerate(sorted(entities))}
+    relation2id = {r: i for i, r in enumerate(sorted(relations))}
+    logger.info(f"  Total: {len(entity2id)} entities, {len(relation2id)} relations")
+
+    # Save mappings
+    _save_id_mapping(entity2id, entity2id_path)
+    _save_id_mapping(relation2id, relation2id_path)
+
+    # Convert and save int triples
+    for split, triples in split_triples.items():
+        if not triples:
+            continue
+        int_triples = torch.tensor(
+            [[entity2id[h], relation2id[r], entity2id[t]] for h, r, t in triples],
+            dtype=torch.long,
+        )
+        pt_path = processed_dir / f"{split}_triples.pt"
+        torch.save(int_triples, pt_path)
+        logger.info(f"  Saved {split}_triples.pt ({int_triples.shape})")
+
+    return entity2id, relation2id
+
+
+def _save_id_mapping(mapping: dict[str, int], path: Path) -> None:
+    """Save string→int mapping as TSV."""
+    with open(path, "w", encoding="utf-8") as f:
+        for key, idx in sorted(mapping.items(), key=lambda x: x[1]):
+            f.write(f"{key}\t{idx}\n")
+
+
+def _load_id_mapping(path: Path) -> dict[str, int]:
+    """Load string→int mapping from TSV."""
+    mapping: dict[str, int] = {}
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            parts = line.strip().split("\t")
+            if len(parts) == 2:
+                mapping[parts[0]] = int(parts[1])
+    return mapping
+
+
+# ─── Stage 2: Text embeddings ────────────────────────────────────────────────
+
+
+def precompute_embeddings(
+    raw_dir: Path,
+    processed_dir: Path,
+    embedder: RiemannFMTextEmbedder,
+    encoder_key: str,
+    dim: int,
+    force: bool = False,
+) -> None:
+    """Precompute text embeddings for entities and relations.
+
+    Texts are loaded in the order defined by entity2id.tsv / relation2id.tsv
+    so that row i of the embedding tensor corresponds to integer ID i.
+
+    Saves to:
+        processed/text_embeddings/entity_emb_{key}_{dim}.pt
+        processed/text_embeddings/relation_emb_{key}_{dim}.pt
+
+    Args:
+        raw_dir: Path to raw/ directory.
+        processed_dir: Path to processed/ directory.
+        embedder: Text embedder instance.
+        encoder_key: Short encoder slug for filenames.
+        dim: Embedding dimension for filenames.
+        force: Re-encode even if files exist.
+    """
+    emb_dir = processed_dir / "text_embeddings"
+    emb_dir.mkdir(parents=True, exist_ok=True)
+
+    # Entity embeddings
+    entity_texts_path = raw_dir / "entity_texts.tsv"
+    entity_id_path = processed_dir / "entity2id.tsv"
+    entity_emb_path = emb_dir / embedding_filename(encoder_key, dim, prefix="entity")
+
+    if entity_texts_path.exists() and entity_id_path.exists():
+        if entity_emb_path.exists() and not force:
+            logger.info(f"Entity embeddings already exist: {entity_emb_path.name}")
+        else:
+            texts = _load_texts_ordered(entity_texts_path, entity_id_path)
+            logger.info(f"Encoding {len(texts)} entity texts with {encoder_key}...")
+            embedder.embed(texts, output_path=entity_emb_path)
+    else:
+        logger.warning(f"entity_texts.tsv or entity2id.tsv not found in {raw_dir}")
+
+    # Relation embeddings
+    relation_texts_path = raw_dir / "relation_texts.tsv"
+    relation_id_path = processed_dir / "relation2id.tsv"
+    relation_emb_path = emb_dir / embedding_filename(encoder_key, dim, prefix="relation")
+
+    if relation_texts_path.exists() and relation_id_path.exists():
+        if relation_emb_path.exists() and not force:
+            logger.info(f"Relation embeddings already exist: {relation_emb_path.name}")
+        else:
+            texts = _load_texts_ordered(relation_texts_path, relation_id_path)
+            logger.info(f"Encoding {len(texts)} relation texts with {encoder_key}...")
+            embedder.embed(texts, output_path=relation_emb_path)
+    else:
+        logger.warning(f"relation_texts.tsv or relation2id.tsv not found in {raw_dir}")
+
+
+def _load_texts_ordered(texts_path: Path, id_path: Path) -> list[str]:
+    """Load texts ordered by integer IDs from an id mapping file.
+
+    Reads ``texts_path`` (id<TAB>text) into a dict, then orders by the
+    integer IDs in ``id_path`` (string_id<TAB>int_id). Only IDs present
+    in the mapping are included; extras in texts_path are dropped.
+
+    Args:
+        texts_path: Path to TSV with ``string_id<TAB>text``.
+        id_path: Path to TSV with ``string_id<TAB>int_id``.
+
+    Returns:
+        List of texts where index i corresponds to integer ID i.
+    """
+    # Build string_id -> text lookup
+    id_to_text: dict[str, str] = {}
+    with open(texts_path, encoding="utf-8") as f:
+        for line in f:
+            parts = line.strip().split("\t", 1)
+            if len(parts) == 2:
+                id_to_text[parts[0]] = parts[1]
+
+    # Load id mapping: string_id -> int_id
+    id_mapping: list[tuple[str, int]] = []
+    with open(id_path, encoding="utf-8") as f:
+        for line in f:
+            parts = line.strip().split("\t")
+            if len(parts) == 2:
+                id_mapping.append((parts[0], int(parts[1])))
+
+    # Sort by int_id and build ordered text list
+    id_mapping.sort(key=lambda x: x[1])
+    n = len(id_mapping)
+    texts = [""] * n
+    missing = 0
+    for string_id, int_id in id_mapping:
+        if string_id in id_to_text:
+            texts[int_id] = id_to_text[string_id]
+        else:
+            missing += 1
+
+    if missing > 0:
+        logger.warning(f"{missing}/{n} IDs in {id_path.name} have no text in {texts_path.name}")
+    else:
+        logger.info(f"Loaded {n} texts aligned with {id_path.name}")
+
+    return texts
+
+
+# ─── Mini dataset builder ───────────────────────────────────────────────────
+
+
+def build_mini_wikidata_5m(
+    source_dir: str = "data/wikidata_5m",
+    output_dir: str = "data/wikidata_5m_mini",
+    max_entities: int = 1000,
+    target_triples: int = 5000,
+    seed: int = 42,
+    force: bool = False,
+) -> Path:
+    """Build a small engineering validation subset from full WikiData5M.
+
+    Uses relation-aware sampling to ensure diverse relation coverage:
+    1. Sample triples from every relation type for coverage
+    2. Fill entity budget with additional triples
+    3. Densify by adding triples within the sampled entity set
+    4. Split into train/val/test (80/10/10)
+
+    Args:
+        source_dir: Path to full WikiData5M dataset (with raw/ subdirectory).
+        output_dir: Path for the mini dataset output.
+        max_entities: Target number of entities (~1K).
+        target_triples: Target number of triples (~5K).
+        seed: Random seed for deterministic sampling.
+        force: Rebuild even if output already exists.
+
+    Returns:
+        Path to the mini dataset raw/ directory.
+    """
+    from riemannfm.data.pipeline.validate import validate_raw
+
+    source_raw = Path(source_dir) / "raw"
+    output_raw = Path(output_dir) / "raw"
+
+    if (output_raw / "train_triples.txt").exists() and not force:
+        logger.info(f"Mini dataset already exists at {output_raw}, skipping. Use force=True to rebuild.")
+        return output_raw
+
+    if not source_raw.exists():
+        raise FileNotFoundError(
+            f'Source data not found at {source_raw}. Run `make download ARGS="data=wikidata_5m"` first.'
+        )
+
+    random.seed(seed)
+    output_raw.mkdir(parents=True, exist_ok=True)
+
+    # ── Load all triples from all splits ────────────────────────────────────
+    all_triples: list[tuple[str, str, str]] = []
+    for split in ("train", "val", "test"):
+        path = _find_split_file(source_raw, split)
+        if path is None:
+            continue
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                parts = line.strip().split("\t")
+                if len(parts) == 3:
+                    all_triples.append((parts[0], parts[1], parts[2]))
+
+    logger.info(f"Loaded {len(all_triples):,} total triples from {source_raw}")
+
+    # ── Phase 1: Relation coverage ──────────────────────────────────────────
+    rel_to_triples: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
+    for h, r, t in all_triples:
+        rel_to_triples[r].append((h, r, t))
+
+    num_relations = len(rel_to_triples)
+    per_rel = max(3, target_triples // num_relations)
+    logger.info(f"  {num_relations} relation types, sampling {per_rel} triples per relation")
+
+    selected: list[tuple[str, str, str]] = []
+    selected_set: set[tuple[str, str, str]] = set()
+    entities: set[str] = set()
+
+    for _rel, triples in rel_to_triples.items():
+        k = min(per_rel, len(triples))
+        sampled = random.sample(triples, k)
+        for triple in sampled:
+            if triple not in selected_set:
+                selected.append(triple)
+                selected_set.add(triple)
+                entities.add(triple[0])
+                entities.add(triple[2])
+
+    logger.info(f"  Phase 1 (relation coverage): {len(selected):,} triples, {len(entities):,} entities")
+
+    # ── Phase 2: Fill entity budget ─────────────────────────────────────────
+    if len(entities) < max_entities:
+        remaining = [t for t in all_triples if t not in selected_set]
+        random.shuffle(remaining)
+        for triple in remaining:
+            if len(entities) >= max_entities:
+                break
+            if triple not in selected_set:
+                selected.append(triple)
+                selected_set.add(triple)
+                entities.add(triple[0])
+                entities.add(triple[2])
+
+        logger.info(f"  Phase 2 (entity budget): {len(selected):,} triples, {len(entities):,} entities")
+
+    # ── Phase 3: Densify ────────────────────────────────────────────────────
+    densified = 0
+    for h, r, t in all_triples:
+        if (h, r, t) not in selected_set and h in entities and t in entities:
+            selected.append((h, r, t))
+            selected_set.add((h, r, t))
+            densified += 1
+
+    logger.info(f"  Phase 3 (densify): +{densified:,} triples → {len(selected):,} total")
+
+    # ── Split into train/val/test (80/10/10) ────────────────────────────────
+    random.shuffle(selected)
+    n = len(selected)
+    n_val = max(1, n // 10)
+    n_test = max(1, n // 10)
+    n_train = n - n_val - n_test
+
+    splits = {
+        "train": selected[:n_train],
+        "val": selected[n_train : n_train + n_val],
+        "test": selected[n_train + n_val :],
+    }
+
+    for split_name, triples in splits.items():
+        out_path = output_raw / f"{split_name}_triples.txt"
+        with open(out_path, "w", encoding="utf-8") as f:
+            for h, r, t in triples:
+                f.write(f"{h}\t{r}\t{t}\n")
+        logger.info(f"  {split_name}: {len(triples):,} triples → {out_path.name}")
+
+    # ── Filter text files ───────────────────────────────────────────────────
+    relations = {r for _, r, _ in selected}
+
+    entity_texts_src = source_raw / "entity_texts.tsv"
+    if entity_texts_src.exists():
+        entity_texts_dst = output_raw / "entity_texts.tsv"
+        _filter_text_file(entity_texts_src, entity_texts_dst, entities)
+        logger.info(f"  Filtered entity_texts.tsv: {len(entities):,} entities")
+
+    relation_texts_src = source_raw / "relation_texts.tsv"
+    if relation_texts_src.exists():
+        relation_texts_dst = output_raw / "relation_texts.tsv"
+        _filter_text_file(relation_texts_src, relation_texts_dst, relations)
+        logger.info(f"  Filtered relation_texts.tsv: {len(relations):,} relations")
+
+    # ── Validate ────────────────────────────────────────────────────────────
+    logger.info("Validating mini dataset...")
+    if not validate_raw(output_dir, slug="wikidata_5m_mini"):
+        logger.warning("Mini dataset validation had warnings — check logs above.")
+
+    logger.info(
+        f"Mini dataset built: {len(entities):,} entities, "
+        f"{len(relations):,} relations, {len(selected):,} triples → {output_raw}"
+    )
+    return output_raw
+
+
+def _filter_text_file(src: Path, dst: Path, keep_ids: set[str]) -> None:
+    """Filter a TSV text file to only include IDs in keep_ids."""
+    with open(src, encoding="utf-8") as fin, open(dst, "w", encoding="utf-8") as fout:
+        for line in fin:
+            parts = line.split("\t", 1)
+            if parts and parts[0] in keep_ids:
+                fout.write(line)
+
+
+# ─── Full pipeline ───────────────────────────────────────────────────────────
+
+
+def run_preprocess(
+    data_dir: str,
+    embedding_provider: str,
+    model_name: str,
+    output_dim: int,
+    batch_size: int = 256,
+    max_length: int = 512,
+    pooling: str = "mean",
+    api_base: str | None = None,
+    api_key: str | None = None,
+    force: bool = False,
+) -> None:
+    """Run the full preprocess pipeline for a single dataset.
+
+    Args:
+        data_dir: Base dataset directory (with raw/ subdirectory).
+        embedding_provider: "huggingface", "ollama", "openai", or "none".
+        model_name: Model name for the embedder.
+        output_dim: Embedding output dimension.
+        batch_size: Encoding batch size.
+        max_length: Max token length (huggingface).
+        pooling: Pooling strategy (huggingface).
+        api_base: API base URL (ollama/openai).
+        api_key: API key (openai).
+        force: Re-run even if outputs exist.
+    """
+    raw_dir = Path(data_dir) / "raw"
+    processed_dir = Path(data_dir) / "processed"
+
+    if not raw_dir.exists():
+        raise FileNotFoundError(f"Raw data not found at {raw_dir}. Run `make download` first.")
+
+    # Stage 1: ID mappings + int triples
+    build_id_mappings(raw_dir, processed_dir, force=force)
+
+    # Stage 2: Text embeddings (skip if none)
+    if embedding_provider == "none":
+        logger.info("embedding_provider=none, skipping text embeddings.")
+        return
+
+    key = encoder_slug(model_name)
+    embedder = RiemannFMTextEmbedder(
+        embedding_provider=embedding_provider,
+        model_name=model_name,
+        output_dim=output_dim,
+        api_base=api_base,
+        api_key=api_key,
+        batch_size=batch_size,
+        max_length=max_length,
+        pooling=pooling,
+    )
+    precompute_embeddings(
+        raw_dir,
+        processed_dir,
+        embedder=embedder,
+        encoder_key=key,
+        dim=output_dim,
+        force=force,
+    )

--- a/src/riemannfm/data/pipeline/preprocess.py
+++ b/src/riemannfm/data/pipeline/preprocess.py
@@ -272,24 +272,33 @@ def _load_texts_ordered(texts_path: Path, id_path: Path) -> list[str]:
 def build_mini_wikidata_5m(
     source_dir: str = "data/wikidata_5m",
     output_dir: str = "data/wikidata_5m_mini",
-    max_entities: int = 1000,
-    target_triples: int = 5000,
+    min_entities: int = 1000,
+    min_triples: int = 5000,
     seed: int = 42,
     force: bool = False,
 ) -> Path:
     """Build a small engineering validation subset from full WikiData5M.
 
     Uses relation-aware sampling to ensure diverse relation coverage:
-    1. Sample triples from every relation type for coverage
-    2. Fill entity budget with additional triples
-    3. Densify by adding triples within the sampled entity set
-    4. Split into train/val/test (80/10/10)
+    1. Sample ``max(3, min_triples // num_relations)`` triples per relation
+       to guarantee coverage; this alone can already overshoot ``min_triples``
+       and ``min_entities`` when num_relations is large.
+    2. If Phase 1 entities < ``min_entities``, fill from remaining triples.
+    3. Densify: add all remaining triples whose h and t are both already in
+       the selected entity set. Densification has no upper bound and is
+       what typically dominates the final size — e.g. with min_triples=5000
+       and min_entities=1000 against the 822-relation WikiData5M we end up
+       with ~7.8K entities / ~23K triples in practice.
+    4. Split into train/val/test (80/10/10).
+
+    ``min_*`` are floors / hints, not caps. If you need a hard cap on the
+    final size, subsample Phase 3's output downstream.
 
     Args:
         source_dir: Path to full WikiData5M dataset (with raw/ subdirectory).
         output_dir: Path for the mini dataset output.
-        max_entities: Target number of entities (~1K).
-        target_triples: Target number of triples (~5K).
+        min_entities: Minimum entity count Phase 2 aims for (may be exceeded by Phase 1).
+        min_triples: Per-relation sampling floor for Phase 1 (may be exceeded by Phase 3 densify).
         seed: Random seed for deterministic sampling.
         force: Rebuild even if output already exists.
 
@@ -333,7 +342,7 @@ def build_mini_wikidata_5m(
         rel_to_triples[r].append((h, r, t))
 
     num_relations = len(rel_to_triples)
-    per_rel = max(3, target_triples // num_relations)
+    per_rel = max(3, min_triples // num_relations)
     logger.info(f"  {num_relations} relation types, sampling {per_rel} triples per relation")
 
     selected: list[tuple[str, str, str]] = []
@@ -353,11 +362,11 @@ def build_mini_wikidata_5m(
     logger.info(f"  Phase 1 (relation coverage): {len(selected):,} triples, {len(entities):,} entities")
 
     # ── Phase 2: Fill entity budget ─────────────────────────────────────────
-    if len(entities) < max_entities:
+    if len(entities) < min_entities:
         remaining = [t for t in all_triples if t not in selected_set]
         random.shuffle(remaining)
         for triple in remaining:
-            if len(entities) >= max_entities:
+            if len(entities) >= min_entities:
                 break
             if triple not in selected_set:
                 selected.append(triple)

--- a/src/riemannfm/data/pipeline/validate.py
+++ b/src/riemannfm/data/pipeline/validate.py
@@ -1,0 +1,213 @@
+"""Validate raw KG download integrity.
+
+Checks triple files, entity/relation text files, and split leakage.
+Called automatically after download, or standalone:
+
+    uv run python -m riemannfm.data.validate data/wikidata_5m
+"""
+
+import logging
+from collections import Counter
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Triple file names in order of preference
+_TRAIN_NAMES = ("train_triples.txt", "train.txt")
+_VAL_NAMES = ("val_triples.txt", "valid.txt")
+_TEST_NAMES = ("test_triples.txt", "test.txt")
+
+
+def _find_file(raw_dir: Path, candidates: tuple[str, ...]) -> Path | None:
+    for name in candidates:
+        p = raw_dir / name
+        if p.exists():
+            return p
+    return None
+
+
+def _check_triples(path: Path, label: str) -> tuple[bool, int, set[str], set[str]]:
+    """Validate a triple file. Returns (ok, count, entities, relations)."""
+    entities: set[str] = set()
+    relations: set[str] = set()
+    bad_lines = 0
+    total = 0
+
+    with open(path, encoding="utf-8") as f:
+        for i, line in enumerate(f):
+            parts = line.strip().split("\t")
+            if len(parts) != 3:
+                bad_lines += 1
+                if bad_lines <= 3:
+                    logger.warning(f"  {label} line {i + 1}: expected 3 columns, got {len(parts)}")
+                continue
+            h, r, t = parts
+            entities.add(h)
+            entities.add(t)
+            relations.add(r)
+            total += 1
+
+    ok = total > 0 and bad_lines == 0
+    status = "OK" if ok else "FAIL"
+    msg = f"  {status}  {label}: {total:,} triples, {len(entities):,} entities, {len(relations):,} relations"
+    if bad_lines:
+        msg += f" ({bad_lines} bad lines)"
+    logger.info(msg)
+    return ok, total, entities, relations
+
+
+def _check_text_file(path: Path, label: str, reference_ids: set[str]) -> bool:
+    """Validate a TSV text file (entity_texts.tsv or relation_texts.tsv)."""
+    if not path.exists():
+        logger.warning(f"  SKIP  {label}: file not found")
+        return True  # optional file, not a hard failure
+
+    text_ids: set[str] = set()
+    empty_text = 0
+    bad_lines = 0
+    total = 0
+
+    with open(path, encoding="utf-8") as f:
+        for i, line in enumerate(f):
+            parts = line.strip().split("\t", 1)
+            if len(parts) != 2:
+                bad_lines += 1
+                if bad_lines <= 3:
+                    logger.warning(f"  {label} line {i + 1}: expected 2 columns, got {len(parts)}")
+                continue
+            tid, text = parts
+            text_ids.add(tid)
+            if not text.strip():
+                empty_text += 1
+            total += 1
+
+    missing = reference_ids - text_ids
+    coverage = (len(reference_ids) - len(missing)) / len(reference_ids) * 100 if reference_ids else 100
+
+    ok = total > 0 and bad_lines == 0
+    status = "OK" if ok else "FAIL"
+    logger.info(f"  {status}  {label}: {total:,} entries, {empty_text:,} empty, {bad_lines} bad lines")
+    logger.info(f"         coverage: {coverage:.1f}% ({len(missing):,} missing)")
+    if missing and len(missing) <= 20:
+        logger.info(f"         missing: {sorted(missing)}")
+    return ok
+
+
+def _check_split_leakage(train: Path, val: Path | None, test: Path | None) -> bool:
+    """Check for triple leakage between splits."""
+
+    def load(p: Path | None) -> set[tuple[str, str, str]]:
+        s: set[tuple[str, str, str]] = set()
+        if p and p.exists():
+            with open(p, encoding="utf-8") as f:
+                for line in f:
+                    parts = line.strip().split("\t")
+                    if len(parts) == 3:
+                        s.add((parts[0], parts[1], parts[2]))
+        return s
+
+    tr, va, te = load(train), load(val), load(test)
+    tv, tt, vt = tr & va, tr & te, va & te
+    clean = len(tv) == 0 and len(tt) == 0 and len(vt) == 0
+    if clean:
+        logger.info("  OK  split leakage: train∩val=0, train∩test=0, val∩test=0")
+    else:
+        logger.warning(
+            f"  WARN  split leakage: train∩val={len(tv)}, train∩test={len(tt)}, val∩test={len(vt)}"
+            " (upstream dataset issue, filtered evaluation handles this)"
+        )
+    # Leakage is a warning, not a hard failure — many public datasets have minor overlap.
+    return True
+
+
+def _log_relation_distribution(train: Path) -> None:
+    """Log top/bottom relations by frequency."""
+    counter: Counter[str] = Counter()
+    with open(train, encoding="utf-8") as f:
+        for line in f:
+            parts = line.strip().split("\t")
+            if len(parts) == 3:
+                counter[parts[1]] += 1
+
+    top = counter.most_common(10)
+    bottom = counter.most_common()[-10:]
+    logger.info(f"  Relation distribution ({len(counter)} unique):")
+    logger.info(f"    top-10:    {', '.join(f'{r}({c:,})' for r, c in top)}")
+    logger.info(f"    bottom-10: {', '.join(f'{r}({c:,})' for r, c in bottom)}")
+
+
+def validate_raw(data_dir: str, slug: str = "") -> bool:
+    """Validate raw download integrity for a dataset.
+
+    Args:
+        data_dir: Base dataset directory (raw/ is appended).
+        slug: Dataset slug for log messages.
+
+    Returns:
+        True if all checks pass.
+    """
+    raw_dir = Path(data_dir) / "raw"
+    label = slug or raw_dir.parent.name
+
+    if not raw_dir.exists():
+        logger.error(f"[{label}] {raw_dir} does not exist")
+        return False
+
+    logger.info(f"[{label}] Validating {raw_dir}/")
+    all_ok = True
+
+    # 1. Triple files
+    train_path = _find_file(raw_dir, _TRAIN_NAMES)
+    val_path = _find_file(raw_dir, _VAL_NAMES)
+    test_path = _find_file(raw_dir, _TEST_NAMES)
+
+    if not train_path:
+        logger.error(f"  FAIL  No training triples found in {raw_dir}")
+        return False
+
+    all_entities: set[str] = set()
+    all_relations: set[str] = set()
+
+    logger.info("[1/5] Triple files")
+    ok, _, ent, rel = _check_triples(train_path, "train")
+    all_ok &= ok
+    all_entities |= ent
+    all_relations |= rel
+
+    for path, name in [(val_path, "val"), (test_path, "test")]:
+        if path:
+            ok, _, ent, rel = _check_triples(path, name)
+            all_ok &= ok
+            all_entities |= ent
+            all_relations |= rel
+
+    logger.info(f"         total unique: {len(all_entities):,} entities, {len(all_relations):,} relations")
+
+    # 2. Entity texts
+    logger.info("[2/5] Entity texts")
+    all_ok &= _check_text_file(raw_dir / "entity_texts.tsv", "entity_texts.tsv", all_entities)
+
+    # 3. Relation texts
+    logger.info("[3/5] Relation texts")
+    all_ok &= _check_text_file(raw_dir / "relation_texts.tsv", "relation_texts.tsv", all_relations)
+
+    # 4. Split leakage
+    logger.info("[4/5] Split leakage")
+    all_ok &= _check_split_leakage(train_path, val_path, test_path)
+
+    # 5. Relation distribution
+    logger.info("[5/5] Relation distribution")
+    _log_relation_distribution(train_path)
+
+    status = "ALL PASSED" if all_ok else "SOME CHECKS FAILED"
+    logger.info(f"[{label}] Validation: {status}")
+    return all_ok
+
+
+if __name__ == "__main__":
+    import sys
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    data_dir = sys.argv[1] if len(sys.argv) > 1 else "data/wikidata_5m"
+    ok = validate_raw(data_dir)
+    sys.exit(0 if ok else 1)

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,59 @@
+"""Smoke tests for the preprocess CLI and embed dispatch.
+
+No network or model loading — these tests exercise helpers that don't
+require a live embedding backend. End-to-end preprocess is validated
+manually against real datasets.
+"""
+
+import pytest
+
+from riemannfm.data.pipeline.embed import (
+    ENCODER_DIMS,
+    embedding_filename,
+    encoder_model_name,
+    encoder_slug,
+)
+
+
+def test_cli_imports() -> None:
+    import riemannfm.cli.preprocess as mod
+
+    assert callable(mod.main)
+
+
+def test_preprocess_imports() -> None:
+    from riemannfm.data.pipeline import preprocess as mod
+
+    for name in ("build_id_mappings", "precompute_embeddings", "build_mini_wikidata_5m", "run_preprocess"):
+        assert hasattr(mod, name), f"preprocess.{name} missing"
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("sentence-transformers/all-MiniLM-L6-v2", "sbert"),
+        ("all-minilm:l6-v2", "sbert"),
+        ("qwen3-embedding", "qwen3"),
+        ("qwen3-embedding:8b", "qwen3"),
+        ("nomic-embed-text", "nomic"),
+    ],
+)
+def test_encoder_slug_canonical(raw: str, expected: str) -> None:
+    assert encoder_slug(raw) == expected
+
+
+def test_encoder_model_name_roundtrip() -> None:
+    for slug in ("sbert", "qwen3", "nomic"):
+        model = encoder_model_name(slug)
+        assert encoder_slug(model) == slug
+
+
+def test_embedding_filename_shape() -> None:
+    assert embedding_filename("qwen3", 768, prefix="entity") == "entity_emb_qwen3_768.pt"
+    assert embedding_filename("sbert", 384, prefix="relation") == "relation_emb_sbert_384.pt"
+
+
+def test_encoder_dims_complete() -> None:
+    assert set(ENCODER_DIMS.keys()) == {"sbert", "qwen3", "nomic"}
+    for slug, dim in ENCODER_DIMS.items():
+        assert dim > 0, slug

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,57 @@
+"""Unit tests for the post-download validate module."""
+
+from pathlib import Path
+
+from riemannfm.data.pipeline.validate import validate_raw
+
+
+def _write(raw_dir: Path, name: str, content: str) -> None:
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / name).write_text(content, encoding="utf-8")
+
+
+def test_validate_raw_clean_dataset(tmp_path: Path) -> None:
+    raw = tmp_path / "raw"
+    _write(
+        raw,
+        "train.txt",
+        "e1\tr1\te2\ne2\tr2\te3\ne3\tr1\te1\n",
+    )
+    _write(raw, "valid.txt", "e1\tr2\te3\n")
+    _write(raw, "test.txt", "e3\tr1\te2\n")
+    _write(
+        raw,
+        "entity_texts.tsv",
+        "e1\tentity one\ne2\tentity two\ne3\tentity three\n",
+    )
+    _write(
+        raw,
+        "relation_texts.tsv",
+        "r1\tfirst relation\nr2\tsecond relation\n",
+    )
+
+    assert validate_raw(str(tmp_path), slug="fake") is True
+
+
+def test_validate_raw_missing_train(tmp_path: Path) -> None:
+    (tmp_path / "raw").mkdir()
+    assert validate_raw(str(tmp_path), slug="fake") is False
+
+
+def test_validate_raw_malformed_triples(tmp_path: Path) -> None:
+    raw = tmp_path / "raw"
+    _write(raw, "train.txt", "e1\tr1\te2\nonly-two-cols\n")
+    # bad lines cause the train check to fail; hard failure.
+    assert validate_raw(str(tmp_path), slug="fake") is False
+
+
+def test_validate_raw_split_leakage_is_soft_warning(tmp_path: Path) -> None:
+    """Split leakage is logged as a warning but does not fail validation."""
+    raw = tmp_path / "raw"
+    _write(raw, "train.txt", "e1\tr1\te2\ne2\tr2\te3\n")
+    _write(raw, "valid.txt", "e1\tr1\te2\n")  # identical to train row
+    _write(raw, "test.txt", "e2\tr2\te3\n")  # identical to train row
+    _write(raw, "entity_texts.tsv", "e1\ta\ne2\tb\ne3\tc\n")
+    _write(raw, "relation_texts.tsv", "r1\tx\nr2\ty\n")
+
+    assert validate_raw(str(tmp_path), slug="fake") is True


### PR DESCRIPTION
Closes #5

## Summary

Migrates the preprocess pipeline from the WIP branch to `main`. Brings post-download validation, multi-backend text embedding, ID mapping, the WikiData5M-mini subset builder, and the `riemannfm-preprocess` CLI.

`validate_raw` was already lazy-imported at the tail of `run_pipeline` in Issue #3 (behind a `try/except ImportError`). With this PR the import succeeds, so post-download validation runs automatically for every future `riemannfm-download` invocation.

## Commits

1. `feat(data): add post-download validate module`
2. `feat(data): add multi-backend text embedder`
3. `feat(data): add preprocess module`
4. `feat(cli): add preprocess CLI with Hydra integration`
5. `feat(configs): add preprocess and embedding defaults`
6. `feat(configs): add wikidata_5m_mini data config`
7. `feat(configs): reference preprocess and embedding groups in config root`
8. `chore(cli,scripts): restore riemannfm-preprocess entry point, Makefile target, wrapper`
9. `test(data): add validate and preprocess smoke/unit tests`

## Scope notes

- Only `configs/embedding/qwen3.yaml` ships (the only backend currently authored on WIP). `sbert`, `nomic`, `none` variants that CLAUDE.md references are deferred to a follow-up Issue.
- `configs/data/wikidata_5m_mini.yaml` uses the same stripped schema as the other data configs (slug, dataset, data_dir, text_source, num_entities, num_edge_types). It is explicitly documented as a preprocess product, not a downloadable dataset.
- All file-reading `open()` calls in `validate.py` carry `encoding="utf-8"` (same hygiene as Issue #3). `embed.py` does not do text file I/O (only `torch.save` / `.pt`).
- `pyproject.toml` now has two entry points (`riemannfm-download`, `riemannfm-preprocess`); the rest remain stripped pending their Issues.
- `configs/config.yaml` gains two defaults (`preprocess`, `embedding`); `model`, `manifold`, `flow`, `training`, `ablation`, `task`, `accelerator`, `logger`, `experiment` continue to be added back as their Issues land.

## Test plan

- [x] `uv sync --group dev` succeeds
- [x] `make lint` passes
- [x] `uv run ruff format --check src/riemannfm tests` passes
- [x] `make typecheck` passes (10 source files)
- [x] `make test` passes (28 tests: 2 package + 12 download + 10 preprocess + 4 validate)
- [x] `uv run python -m riemannfm.cli.preprocess --help` composes full config
- [ ] GitHub Actions CI green on PR
- [ ] Manual: `uv run python -m riemannfm.cli.preprocess data=wikidata_5m_mini preprocess.build_mini=true` produces a mini/ tree (validated manually against the already-downloaded `data/wikidata_5m/`)
