### PR TITLE
refactor(cli)[#8]: replace download.all with hydra --multirun

### DIFF
--- a/configs/download/default.yaml
+++ b/configs/download/default.yaml
@@ -1,2 +1,1 @@
 force: false
-all: false

--- a/src/riemannfm/cli/download.py
+++ b/src/riemannfm/cli/download.py
@@ -4,78 +4,33 @@ Downloads graph structure and entity text descriptions into data/{dataset}/raw/.
 Text embedding precomputation is handled by the preprocess CLI.
 
 Single dataset:
-    python -m riemannfm.cli.download data=fb15k237
+    python -m riemannfm.cli.download data=fb15k_237
     python -m riemannfm.cli.download data=wn18rr
 
-All datasets:
-    python -m riemannfm.cli.download download.all=true
+All datasets (Hydra multirun):
+    python -m riemannfm.cli.download --multirun \\
+        data=wikidata_5m,fb15k_237,wn18rr,codex_l,wiki27k,yago3_10
 """
 
 import logging
 
 import hydra
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig
 
-from riemannfm.data.pipeline.download import ALL_DATASETS, run_pipeline
+from riemannfm.data.pipeline.download import run_pipeline
 
 logger = logging.getLogger(__name__)
 
 
 @hydra.main(version_base=None, config_path="../../../configs", config_name="config")
 def main(cfg: DictConfig):
-    force = cfg.download.force
-
-    if cfg.download.all:
-        logger.info("Downloading ALL datasets...")
-        for slug in ALL_DATASETS:
-            data_cfg = _load_data_config(slug)
-            if data_cfg is None:
-                logger.warning(f"No data config found for slug={slug}, skipping.")
-                continue
-            run_pipeline(
-                slug=slug,
-                data_dir=data_cfg["data_dir"],
-                text_source=data_cfg["text_source"],
-                force=force,
-            )
-    else:
-        slug = cfg.data.slug
-        run_pipeline(
-            slug=slug,
-            data_dir=cfg.data.data_dir,
-            text_source=cfg.data.text_source,
-            force=force,
-        )
-
+    run_pipeline(
+        slug=cfg.data.slug,
+        data_dir=cfg.data.data_dir,
+        text_source=cfg.data.text_source,
+        force=cfg.download.force,
+    )
     logger.info("Download complete.")
-
-
-def _load_data_config(slug: str) -> dict | None:
-    """Load a data config YAML by dataset slug.
-
-    Scans configs/data/*.yaml to find the one matching the given slug.
-    Returns a dict with data_dir and text_source, or None if not found.
-    """
-    from pathlib import Path
-
-    config_dir = Path(__file__).resolve().parent.parent.parent.parent / "configs" / "data"
-    if not config_dir.exists():
-        return None
-
-    for yaml_file in config_dir.glob("*.yaml"):
-        try:
-            data_cfg = OmegaConf.load(yaml_file)
-            if not isinstance(data_cfg, DictConfig):
-                continue
-            if data_cfg.get("slug") == slug:
-                return {
-                    "data_dir": data_cfg.get("data_dir", f"data/{slug}"),
-                    "text_source": data_cfg.get("text_source", ""),
-                }
-        except Exception:
-            continue
-
-    return None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Delete `download.all` flag and `_load_data_config` helper from [src/riemannfm/cli/download.py](src/riemannfm/cli/download.py); the CLI now always reads `cfg.data` through Hydra.
- Drop `all: false` from [configs/download/default.yaml](configs/download/default.yaml) — `download.*` only contains `force` now.
- Canonical "download everything" invocation is the Hydra-native multirun form:
  ```bash
  uv run python -m riemannfm.cli.download --multirun \
      data=wikidata_5m,fb15k_237,wn18rr,codex_l,wiki27k,yago3_10
  ```

## Why

`_load_data_config` scanned `configs/data/*.yaml` with a raw `OmegaConf.load()`, bypassing Hydra's composition pipeline. Interpolations like `${paths.data_dir}` were never resolved — the literal template string was passed to `run_pipeline`. The gap only triggered under `download.all=true` (single-dataset runs went through `@hydra.main` normally), so it hadn't surfaced in practice. `--multirun` delegates the iteration to Hydra, composes each data config properly, and eliminates the bespoke loader.

Originally flagged in PR #4 review item #10.

## Test plan

- [x] `make lint` — passes.
- [x] `make typecheck` — passes (10 source files clean).
- [x] `make test` — 28/28 passing, including `test_cli_imports` and `test_all_datasets_enumerated`.
- [x] Hydra compose sanity check: `cfg.download == {'force': False}`, `cfg.data.data_dir` resolves to an absolute path (no leftover `${paths.data_dir}` literal).
- [ ] Manual: `uv run python -m riemannfm.cli.download --multirun data=fb15k_237,wn18rr` downloads both datasets end-to-end (deferred — network-dependent smoke test, not gating merge).

Closes #8