### PR TITLE
chore(data)[#7]: preprocess nits + sbert config + last_token pooling test

### DIFF
--- a/configs/embedding/sbert.yaml
+++ b/configs/embedding/sbert.yaml
@@ -1,0 +1,6 @@
+embedding_provider: huggingface
+model_name: sentence-transformers/all-MiniLM-L6-v2
+output_dim: 384
+freeze: true
+pooling: mean
+max_length: 128

--- a/src/riemannfm/data/pipeline/embed.py
+++ b/src/riemannfm/data/pipeline/embed.py
@@ -416,7 +416,11 @@ class RiemannFMTextEmbedder:
         n_failed_concurrent = len(failed)
         n_recovered = len(seq_recovered)
         n_permanent = len(permanently_failed)
-        n_retried_inline = len(retried_batches - {idx for idx, _ in failed})
+        # retried_batches is populated only on the success path at L354
+        # (inside 'if attempt > 0' before 'return'), so it is disjoint
+        # from 'failed' by construction — the earlier set subtraction
+        # was a no-op.
+        n_retried_inline = len(retried_batches)
         n_first_try = n_total - n_retried_inline - n_failed_concurrent
 
         summary_lines = [

--- a/src/riemannfm/data/pipeline/preprocess.py
+++ b/src/riemannfm/data/pipeline/preprocess.py
@@ -319,7 +319,7 @@ def build_mini_wikidata_5m(
             f'Source data not found at {source_raw}. Run `make download ARGS="data=wikidata_5m"` first.'
         )
 
-    random.seed(seed)
+    rng = random.Random(seed)
     output_raw.mkdir(parents=True, exist_ok=True)
 
     # ── Load all triples from all splits ────────────────────────────────────
@@ -351,7 +351,7 @@ def build_mini_wikidata_5m(
 
     for _rel, triples in rel_to_triples.items():
         k = min(per_rel, len(triples))
-        sampled = random.sample(triples, k)
+        sampled = rng.sample(triples, k)
         for triple in sampled:
             if triple not in selected_set:
                 selected.append(triple)
@@ -364,7 +364,7 @@ def build_mini_wikidata_5m(
     # ── Phase 2: Fill entity budget ─────────────────────────────────────────
     if len(entities) < min_entities:
         remaining = [t for t in all_triples if t not in selected_set]
-        random.shuffle(remaining)
+        rng.shuffle(remaining)
         for triple in remaining:
             if len(entities) >= min_entities:
                 break
@@ -387,7 +387,7 @@ def build_mini_wikidata_5m(
     logger.info(f"  Phase 3 (densify): +{densified:,} triples → {len(selected):,} total")
 
     # ── Split into train/val/test (80/10/10) ────────────────────────────────
-    random.shuffle(selected)
+    rng.shuffle(selected)
     n = len(selected)
     n_val = max(1, n // 10)
     n_test = max(1, n // 10)

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -1,0 +1,93 @@
+"""Unit tests for embed.py.
+
+These tests target branches of ``_embed_huggingface`` that no shipped
+embedding config currently exercises (e.g. ``pooling='last_token'``
+against a huggingface-served decoder model). We mock the tokenizer
+and model so no weights are downloaded.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+
+from riemannfm.data.pipeline.embed import RiemannFMTextEmbedder
+
+
+class _FakeTokenizerOut(dict):
+    """Dict subclass so ``{k: v.cuda() ...}`` and ``self._hf_model(**inputs)`` both work."""
+
+
+def _make_fake_tokenizer(input_ids: torch.Tensor, attention_mask: torch.Tensor):
+    def tokenizer(*_args: Any, **_kwargs: Any) -> _FakeTokenizerOut:
+        return _FakeTokenizerOut(input_ids=input_ids, attention_mask=attention_mask)
+
+    return tokenizer
+
+
+def _make_fake_model(last_hidden_state: torch.Tensor):
+    def model(**_inputs: Any) -> SimpleNamespace:
+        return SimpleNamespace(last_hidden_state=last_hidden_state)
+
+    return model
+
+
+@pytest.fixture
+def force_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+
+def test_embed_huggingface_last_token(force_cpu: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify the last_token pooling branch picks hidden[seq_len - 1]."""
+    # Two sequences (lengths 3 and 2) padded to length 3. Hidden size 4.
+    hidden = torch.arange(24, dtype=torch.float).reshape(2, 3, 4)
+    attention_mask = torch.tensor([[1, 1, 1], [1, 1, 0]])
+    input_ids = torch.zeros(2, 3, dtype=torch.long)
+
+    def fake_load(self: RiemannFMTextEmbedder) -> None:
+        self._hf_tokenizer = _make_fake_tokenizer(input_ids, attention_mask)
+        self._hf_model = _make_fake_model(hidden)
+
+    monkeypatch.setattr(RiemannFMTextEmbedder, "_load_hf_model", fake_load)
+
+    embedder = RiemannFMTextEmbedder(
+        embedding_provider="huggingface",
+        model_name="fake",
+        output_dim=4,
+        batch_size=2,
+        pooling="last_token",
+    )
+    result = embedder._embed_huggingface(["text_a", "text_b"])
+
+    # text_a: length 3 → seq_len=2 → hidden[0, 2] = [8, 9, 10, 11]
+    # text_b: length 2 → seq_len=1 → hidden[1, 1] = [16, 17, 18, 19]
+    expected = torch.tensor([[8.0, 9.0, 10.0, 11.0], [16.0, 17.0, 18.0, 19.0]])
+    torch.testing.assert_close(result, expected)
+
+
+def test_embed_huggingface_mean_pooling(force_cpu: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sanity check: mean-pooling branch averages over non-padding tokens."""
+    hidden = torch.arange(24, dtype=torch.float).reshape(2, 3, 4)
+    attention_mask = torch.tensor([[1, 1, 1], [1, 1, 0]])
+    input_ids = torch.zeros(2, 3, dtype=torch.long)
+
+    def fake_load(self: RiemannFMTextEmbedder) -> None:
+        self._hf_tokenizer = _make_fake_tokenizer(input_ids, attention_mask)
+        self._hf_model = _make_fake_model(hidden)
+
+    monkeypatch.setattr(RiemannFMTextEmbedder, "_load_hf_model", fake_load)
+
+    embedder = RiemannFMTextEmbedder(
+        embedding_provider="huggingface",
+        model_name="fake",
+        output_dim=4,
+        batch_size=2,
+        pooling="mean",
+    )
+    result = embedder._embed_huggingface(["text_a", "text_b"])
+
+    # text_a: mean of rows 0,1,2 → hidden[0].mean(dim=0) = [4, 5, 6, 7]
+    # text_b: mean of rows 0,1 only (mask 1,1,0) → hidden[1, :2].mean(dim=0) = [14, 15, 16, 17]
+    expected = torch.tensor([[4.0, 5.0, 6.0, 7.0], [14.0, 15.0, 16.0, 17.0]])
+    torch.testing.assert_close(result, expected)


### PR DESCRIPTION
Closes #7

## Summary

Cleans up the three non-blocking nits from PR #6 review. Plus adds a huggingface-backend embedding config (`sbert.yaml`) whose presence surfaces the huggingface branch in `_embed_batch` for the first time, and two unit tests that exercise the previously-dead `last_token` pooling formula using a mocked tokenizer/model.

## Commits

1. `fix(data): isolate build_mini RNG via random.Random instance` — no more global `random.seed` pollution; all 4 sampling sites inside `build_mini_wikidata_5m` now go through a local `rng`.
2. `fix(data): drop identity set-subtraction in embed summary` — `retried_batches - {idx for idx, _ in failed}` simplifies to `len(retried_batches)` (they're disjoint by construction, with a note explaining why).
3. `feat(configs): add sbert embedding config` — `huggingface` provider + `mean` pooling, 384-dim MiniLM. Gives users a GPU/ollama-free path.
4. `test(data): exercise _embed_huggingface last_token and mean pooling` — monkeypatched tokenizer/model, two tests asserting exact output tensors.

## Scope notes

- No model weights downloaded by the new tests — they run CPU-only in <1s.
- `sbert.yaml` uses `pooling: mean` (the SBERT default); `last_token` remains exercised only by the unit test for now. When an HF-served Qwen3 config lands later, it will reuse that pooling branch.
- `n_retried_inline` semantics unchanged — the summary still counts in-line retries; just no longer subtracts an empty set.

## Test plan

- [x] `make lint` / `ruff format --check` / `make typecheck` pass
- [x] `make test` passes (30 tests: 2 package + 12 download + 10 preprocess + 2 embed + 4 validate)
- [x] `uv run python -m riemannfm.cli.preprocess data=fb15k_237 embedding=sbert --cfg job` composes full config
- [ ] GitHub Actions CI green on PR
